### PR TITLE
feat(logging): Add attestation logging

### DIFF
--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -68,6 +68,7 @@ go_library(
         "//beacon-chain/startup:go_default_library",
         "//beacon-chain/state:go_default_library",
         "//beacon-chain/state/stategen:go_default_library",
+        "//beacon-chain/logging:go_default_library",
         "//config/features:go_default_library",
         "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",

--- a/beacon-chain/blockchain/log.go
+++ b/beacon-chain/blockchain/log.go
@@ -1,12 +1,14 @@
 package blockchain
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/blocks"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/logging"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 	consensus_types "github.com/prysmaticlabs/prysm/v5/consensus-types"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/interfaces"
@@ -107,6 +109,9 @@ func logBlockSyncStatus(block interfaces.ReadOnlyBeaconBlock, blockRoot [32]byte
 			"epoch":          slots.ToEpoch(block.Slot()),
 		}).Info("Synced new block")
 	}
+
+	logging.AttestationLoggerInstance.Summary(context.Background(), slots.ToEpoch(block.Slot()))
+
 	return nil
 }
 

--- a/beacon-chain/core/helpers/metrics.go
+++ b/beacon-chain/core/helpers/metrics.go
@@ -14,4 +14,12 @@ var (
 		Name: "attestation_too_late_total",
 		Help: "Increased when an attestation is considered too late",
 	})
+	AttSuccessfullCount = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "attestation_succesfull",
+		Help: "Increased when an attestation is considered verified",
+	})
+	AttFailedCount = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "attestation_failed",
+		Help: "Increased when an attestation failed",
+	})
 )

--- a/beacon-chain/logging/BUILD.bazel
+++ b/beacon-chain/logging/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@prysm//tools/go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "attestation_logger.go",
+         "log.go",
+    ],
+    importpath = "github.com/prysmaticlabs/prysm/v5/beacon-chain/logging",
+    visibility = ["//beacon-chain:__subpackages__"],
+    deps = [
+        "//monitoring/tracing/trace:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "//consensus-types/primitives:go_default_library",
+        "//time/slots:go_default_library",
+        "//beacon-chain/core/helpers:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "attestation_logger_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "@com_github_sirupsen_logrus//:go_default_library",
+    ],
+)

--- a/beacon-chain/logging/attestation_logger.go
+++ b/beacon-chain/logging/attestation_logger.go
@@ -1,0 +1,119 @@
+package logging
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/helpers"
+	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
+	prysmTrace "github.com/prysmaticlabs/prysm/v5/monitoring/tracing/trace"
+	"github.com/prysmaticlabs/prysm/v5/time/slots"
+)
+
+type AttestationLogger struct {
+	mu              sync.Mutex
+	successfulCount int
+	failedCount     int
+	currentEpoch    primitives.Epoch
+	failureReasons  map[string]int
+}
+
+// AttestationLoggerInstance is a global instance of AttestationLogger
+var AttestationLoggerInstance = NewAttestationLogger()
+
+// NewAttestationLogger creates a new instance of AttestationLogger
+func NewAttestationLogger() *AttestationLogger {
+	_, span := prysmTrace.StartSpan(context.Background(), "processPendingBlocks")
+	defer span.End()
+
+	return &AttestationLogger{
+		failureReasons: make(map[string]int),
+	}
+}
+
+// Success increments the count of successful attestations
+func (al *AttestationLogger) Success(ctx context.Context, slot primitives.Slot) {
+	_, span := prysmTrace.StartSpan(ctx, "logSuccess")
+	defer span.End()
+
+	al.mu.Lock()
+	defer al.mu.Unlock()
+
+	epoch := slots.ToEpoch(slot)
+	if al.currentEpoch == epoch || al.currentEpoch == 0 {
+		helpers.AttSuccessfullCount.Inc() // promethes metrics
+		al.successfulCount++
+	}
+
+	log.Info(fmt.Sprintf("Successful verified attestation for epoch %v", epoch))
+}
+
+// Failure increments the count of failed attestations and logs the reason
+func (al *AttestationLogger) Failure(ctx context.Context, reason string, slot primitives.Slot) {
+	_, span := prysmTrace.StartSpan(ctx, fmt.Sprintf("logFailure: %s", reason))
+	defer span.End()
+
+	al.mu.Lock()
+	defer al.mu.Unlock()
+
+	epoch := slots.ToEpoch(slot)
+	if al.currentEpoch == epoch || al.currentEpoch == 0 {
+		helpers.AttFailedCount.Inc() // promethes metrics
+		al.failedCount++
+		al.failureReasons[reason]++
+	}
+
+	log.Error(fmt.Sprintf("Failed attestation for epoch %v", epoch))
+}
+
+// Summary logs a summary of successful and failed attestations
+func (al *AttestationLogger) Summary(ctx context.Context, epoch primitives.Epoch) {
+	_, span := prysmTrace.StartSpan(ctx, "outputSummary")
+	defer span.End()
+
+	if al.currentEpoch != epoch {
+
+		al.mu.Lock()
+		defer al.mu.Unlock()
+
+		log.Info("##################################")
+		log.Info(fmt.Sprintf("Attestation stats for epoch: %d", al.currentEpoch))
+		log.Info(fmt.Sprintf("Successful verified attestations: %d", al.successfulCount))
+		log.Info(fmt.Sprintf("Failed attestations: %d", al.failedCount))
+		log.Info("##################################")
+
+		for reason, count := range al.failureReasons {
+			log.Info(fmt.Sprintf("Failure reason: %s, count: %d", reason, count))
+		}
+
+		al.currentEpoch = epoch
+		al.resetCounters(ctx)
+	}
+}
+
+// ResetCounters resets the counters and map
+func (al *AttestationLogger) resetCounters(ctx context.Context) {
+	_, span := prysmTrace.StartSpan(ctx, "resetCounters")
+	defer span.End()
+
+	// reset metrics
+	helpers.AttSuccessfullCount.Set(0)
+	helpers.AttSuccessfullCount.Set(0)
+
+	// Reset counters for the next epoch
+	al.successfulCount = 0
+	al.failedCount = 0
+	al.failureReasons = make(map[string]int)
+
+	log.Info("Reseting attestation counters")
+}
+
+// NOTE: If needed we can add this verification to avoid OOM
+// checkAndResetIfNeeded checks the size of the failureReasons map and resets it if it exceeds the maxFailures limit
+/*func (al *AttestationLogger) checkAndResetIfNeeded() {
+	if len(al.failureReasons) > al.maxFailures {
+		log.Printf("Failure reasons map size exceeded %d entries, resetting map", al.maxFailures)
+		al.Summary()
+	}
+}*/

--- a/beacon-chain/logging/attestation_logger_test.go
+++ b/beacon-chain/logging/attestation_logger_test.go
@@ -1,0 +1,97 @@
+package logging
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
+	"github.com/prysmaticlabs/prysm/v5/time/slots"
+)
+
+// TestNewAttestationLogger verifies that a new instance of AttestationLogger is created correctly.
+func TestNewAttestationLogger(t *testing.T) {
+	logger := NewAttestationLogger()
+
+	if logger == nil {
+		t.Errorf("expected a new instance of AttestationLogger, got nil")
+	}
+
+	if len(logger.failureReasons) != 0 {
+		t.Errorf("expected failureReasons map to be empty, got %d", len(logger.failureReasons))
+	}
+}
+
+// TestSuccess verifies that the Success function correctly increments the successfulCount.
+func TestSuccess(t *testing.T) {
+	logger := NewAttestationLogger()
+
+	slot := primitives.Slot(6249440)
+	logger.Success(context.Background(), slot)
+
+	if logger.successfulCount != 1 {
+		t.Errorf("expected successfulCount to be 1, got %d", logger.successfulCount)
+	}
+}
+
+// TestFailure verifies that the Failure function correctly increments the failedCount and updates the failureReasons map.
+func TestFailure(t *testing.T) {
+	logger := NewAttestationLogger()
+
+	reason := "test failure"
+	slot := primitives.Slot(6249440)
+	logger.Failure(context.Background(), reason, slot)
+
+	if logger.failedCount != 1 {
+		t.Errorf("expected failedCount to be 1, got %d", logger.failedCount)
+	}
+
+	if count, exists := logger.failureReasons[reason]; !exists || count != 1 {
+		t.Errorf("expected failureReasons[%s] to be 1, got %d", reason, count)
+	}
+}
+
+// TestSummary verifies that the Summary function correctly logs the summary and resets the counters and map.
+func TestSummary(t *testing.T) {
+	logger := NewAttestationLogger()
+
+	ctx := context.Background()
+	slot := primitives.Slot(6249440)
+	epoch := slots.ToEpoch(slot / 32)
+
+	logger.Success(ctx, slot)
+	logger.Failure(ctx, "test failure 1", slot)
+	logger.Failure(ctx, "test failure 2", slot)
+
+	logger.Summary(ctx, epoch)
+
+	if logger.currentEpoch != epoch {
+		t.Errorf("expected epoch to be %d got %v", logger.currentEpoch, epoch)
+	}
+
+}
+
+// TestResetCounters verifies that the resetCounters function correctly resets the counters and map.
+func TestResetCounters(t *testing.T) {
+	logger := NewAttestationLogger()
+
+	ctx := context.Background()
+	slot := primitives.Slot(6249440)
+
+	logger.Success(ctx, slot)
+	logger.Failure(ctx, "test failure 1", slot)
+	logger.Failure(ctx, "test failure 2", slot)
+
+	logger.resetCounters(ctx)
+
+	if logger.successfulCount != 0 {
+		t.Errorf("expected successfulCount to be reset to 0, got %d", logger.successfulCount)
+	}
+
+	if logger.failedCount != 0 {
+		t.Errorf("expected failedCount to be reset to 0, got %d", logger.failedCount)
+	}
+
+	if len(logger.failureReasons) != 0 {
+		t.Errorf("expected failureReasons to be reset to empty, got %d", len(logger.failureReasons))
+	}
+}

--- a/beacon-chain/logging/doc.go
+++ b/beacon-chain/logging/doc.go
@@ -1,0 +1,8 @@
+/*
+Package logging implements the service to support logging for the Ethereum beacon chain. This package contains
+the necessary components to track and log successful and failed attestations, including the reasons for failures.
+It provides a mechanism to periodically output a summary of the collected data and reset the counters to prevent
+memory overflow. The logging functionality is designed to be thread-safe and efficient, ensuring that it can handle
+the concurrent nature of blockchain operations.
+*/
+package logging

--- a/beacon-chain/logging/log.go
+++ b/beacon-chain/logging/log.go
@@ -1,0 +1,5 @@
+package logging
+
+import "github.com/sirupsen/logrus"
+
+var log = logrus.WithField("prefix", "attestation")


### PR DESCRIPTION
This PR aims to add a logging feature to record attestation metrics (failed/success) to Prysm and also generate metrics in Prometheus. After each epoch the system will generate a summary of the total successes/failures.

Since the task was on a tight deadline, I did not provide documentation; instead, I recorded a [loom](https://www.loom.com/share/25060d1b950949e781e1f8330d36a3fb?sid=ae255eb2-b2ce-4462-afd5-ae6c15f8d248) explaining the implementation.
